### PR TITLE
Disable pybindgen bindings by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ SET(CXX_DISABLE_WERROR True)
 
 SETUP_PROJECT()
 
-option(PYTHON_BINDING "Generate python binding." ON)
+option(PYTHON_BINDING "Generate python binding." OFF)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++0x -pedantic")
 


### PR DESCRIPTION
This causes problems when installing PG from a script on a machine that does not have Pybindgen.